### PR TITLE
fix: Use entity struct instead of Get/QueryOutputItem struct when get

### DIFF
--- a/raiden-derive/src/ops/get.rs
+++ b/raiden-derive/src/ops/get.rs
@@ -7,7 +7,6 @@ pub(crate) fn expand_get_item(
     fields: &syn::FieldsNamed,
     rename_all_type: crate::rename::RenameAllType,
 ) -> proc_macro2::TokenStream {
-    let item_output_name = format_ident!("{}GetItemOutput", struct_name);
     let trait_name = format_ident!("{}GetItem", struct_name);
     let client_name = format_ident!("{}Client", struct_name);
     let builder_name = format_ident!("{}GetItemBuilder", struct_name);
@@ -35,11 +34,6 @@ pub(crate) fn expand_get_item(
     };
 
     quote! {
-        #[derive(Debug, Clone, PartialEq)]
-        pub struct #item_output_name {
-            #(#output_fields)*
-        }
-
         pub trait #trait_name {
             fn get(&self, key: impl ::raiden::IntoAttribute + std::marker::Send) -> #builder_name;
         }
@@ -72,13 +66,13 @@ pub(crate) fn expand_get_item(
 
             #sort_key_setter
 
-            async fn run(self) -> Result<::raiden::get::GetOutput<#item_output_name>, ::raiden::RaidenError> {
+            async fn run(self) -> Result<::raiden::get::GetOutput<#struct_name>, ::raiden::RaidenError> {
                  let res = self.client.get_item(self.input).await?;
                  if res.item.is_none() {
                      return Err(::raiden::RaidenError::ResourceNotFound("resource not found".to_owned()));
                  };
                  let res_item = &res.item.unwrap();
-                 let item = #item_output_name {
+                 let item = #struct_name {
                     #(#from_item)*
                  };
                  Ok(::raiden::get::GetOutput {

--- a/raiden/examples/query.rs
+++ b/raiden/examples/query.rs
@@ -1,6 +1,6 @@
 use raiden::*;
 
-#[derive(Raiden)]
+#[derive(Raiden, Debug)]
 #[raiden(table_name = "QueryTestData0")]
 pub struct QueryTestData0 {
     #[raiden(partition_key)]

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -7,7 +7,7 @@ mod tests {
 
     #[derive(Raiden)]
     #[raiden(table_name = "user")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct User {
         #[raiden(partition_key)]
         id: String,
@@ -32,7 +32,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: UserGetItemOutput {
+                    item: User {
                         id: "user_primary_key".to_owned(),
                         name: "bokuweb".to_owned(),
                         num_usize: 42,
@@ -60,7 +60,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: UserGetItemOutput {
+                    item: User {
                         id: "user_primary_key".to_owned(),
                         name: "bokuweb".to_owned(),
                         num_usize: 42,
@@ -97,7 +97,7 @@ mod tests {
 
     #[derive(Raiden)]
     #[raiden(table_name = "user")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct UserWithUnStored {
         #[raiden(partition_key)]
         id: String,

--- a/raiden/tests/all/query.rs
+++ b/raiden/tests/all/query.rs
@@ -5,7 +5,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use raiden::*;
 
-    #[derive(Raiden)]
+    #[derive(Raiden, Debug, PartialEq)]
     pub struct QueryTestData0 {
         #[raiden(partition_key)]
         id: String,
@@ -31,13 +31,13 @@ mod tests {
                     consumed_capacity: None,
                     count: Some(2),
                     items: vec![
-                        QueryTestData0QueryOutput {
+                        QueryTestData0 {
                             id: "id0".to_owned(),
                             name: "john".to_owned(),
                             year: 1999,
                             num: 1000,
                         },
-                        QueryTestData0QueryOutput {
+                        QueryTestData0 {
                             id: "id0".to_owned(),
                             name: "john".to_owned(),
                             year: 2000,
@@ -70,7 +70,7 @@ mod tests {
                 query::QueryOutput {
                     consumed_capacity: None,
                     count: Some(1),
-                    items: vec![QueryTestData0QueryOutput {
+                    items: vec![QueryTestData0 {
                         id: "id0".to_owned(),
                         name: "john".to_owned(),
                         year: 1999,

--- a/raiden/tests/all/rename.rs
+++ b/raiden/tests/all/rename.rs
@@ -7,7 +7,7 @@ mod tests {
 
     #[derive(Raiden)]
     #[raiden(table_name = "RenameTestData0")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct RenameTest {
         #[raiden(partition_key)]
         id: String,
@@ -18,7 +18,7 @@ mod tests {
 
     #[derive(Raiden)]
     #[raiden(table_name = "RenameTestData0")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct RenameKeyTest {
         #[raiden(partition_key)]
         #[raiden(rename = "id")]
@@ -41,7 +41,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: RenameTestGetItemOutput {
+                    item: RenameTest {
                         id: "id0".to_owned(),
                         name: "john".to_owned(),
                         before_rename: 1999,
@@ -70,7 +70,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: RenameKeyTestGetItemOutput {
+                    item: RenameKeyTest {
                         before_renamed_id: "id0".to_owned(),
                         name: "john".to_owned(),
                         before_rename: 1999,
@@ -99,7 +99,7 @@ mod tests {
                 query::QueryOutput {
                     consumed_capacity: None,
                     count: Some(1),
-                    items: vec![RenameTestQueryOutput {
+                    items: vec![RenameTest {
                         id: "id0".to_owned(),
                         name: "john".to_owned(),
                         before_rename: 1999,

--- a/raiden/tests/all/rename_all.rs
+++ b/raiden/tests/all/rename_all.rs
@@ -8,7 +8,7 @@ mod tests {
     #[derive(Raiden)]
     #[raiden(table_name = "RenameAllCamelCaseTestData0")]
     #[raiden(rename_all = "camelCase")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct RenameAllCamelCaseTest {
         #[raiden(partition_key)]
         partition_key: String,
@@ -29,7 +29,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: RenameAllCamelCaseTestGetItemOutput {
+                    item: RenameAllCamelCaseTest {
                         partition_key: "id0".to_owned(),
                         foo_bar: "john".to_owned(),
                         project_id: 1,
@@ -44,7 +44,7 @@ mod tests {
     #[derive(Raiden)]
     #[raiden(table_name = "RenameAllPascalCaseTestData0")]
     #[raiden(rename_all = "PascalCase")]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct RenameAllPascalCaseTest {
         #[raiden(partition_key)]
         partition_key: String,
@@ -65,7 +65,7 @@ mod tests {
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {
-                    item: RenameAllPascalCaseTestGetItemOutput {
+                    item: RenameAllPascalCaseTest {
                         partition_key: "id0".to_owned(),
                         foo_bar: "john".to_owned(),
                         project_id: 1,


### PR DESCRIPTION
## What does this change?

I use `#struct_name` for get/query output item instead of `format_ident!("{}QueryOutput", struct_name` or `format_ident!("{}GetItemOutput", struct_name`. I think It makes more simple. FYI @kuy  

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

NA
