### PR TITLE
Use actions/cache@v2 for speed up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
           toolchain: stable
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -35,7 +35,7 @@ jobs:
         uses: rrainn/dynamodb-action@v2.0.0
         with:
           port: 8000
-          cors: '*'
+          cors: "*"
       - name: setup data
         run: AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy node setup
       - name: test


### PR DESCRIPTION
## What does this change?

Use `actions/cache@v2` instead of `actions/cache@v1`.

## References

- https://github.com/actions/cache/releases/tag/v2.0.0

## Screenshots

N/A

## What can I check for bug fixes?

N/A
