### PR TITLE
fix: FromAttribute interface to support empty hashSet and vec

### DIFF
--- a/raiden-derive/src/ops/shared.rs
+++ b/raiden-derive/src/ops/shared.rs
@@ -22,7 +22,7 @@ pub(crate) fn expand_attr_to_item(
                 if item.is_none() {
                     None
                 } else {
-                    let converted = ::raiden::FromAttribute::from_attr(item.unwrap().clone());
+                    let converted = ::raiden::FromAttribute::from_attr(item.cloned());
                     if converted.is_err() {
                         return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
                     }
@@ -34,11 +34,9 @@ pub(crate) fn expand_attr_to_item(
             quote! {
               #ident: {
                 let item = #item_ident.get(#attr_key);
-                if item.is_none() {
-                    return Err(::raiden::RaidenError::AttributeValueNotFoundError{ attr_name: #attr_key.to_string() });
-                }
-                let converted = ::raiden::FromAttribute::from_attr(item.unwrap().clone());
+                let converted = ::raiden::FromAttribute::from_attr(item.cloned());
                 if converted.is_err() {
+                  // TODO: improve error handling.
                     return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
                 }
                 converted.unwrap()

--- a/raiden/examples/put.rs
+++ b/raiden/examples/put.rs
@@ -19,8 +19,8 @@ impl raiden::IntoAttribute for CustomId {
 }
 
 impl raiden::FromAttribute for CustomId {
-    fn from_attr(value: raiden::AttributeValue) -> Result<Self, ()> {
-        Ok(CustomId(value.s.unwrap()))
+    fn from_attr(value: Option<raiden::AttributeValue>) -> Result<Self, ()> {
+        Ok(CustomId(value.unwrap().s.unwrap()))
     }
 }
 

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -116,9 +116,80 @@ mod tests {
             let res = client.get("user_primary_key").consistent().run().await;
             assert_eq!(
                 res,
-                Err(RaidenError::AttributeValueNotFoundError {
+                // Err(RaidenError::AttributeValueNotFoundError {
+                //     attr_name: "unstored".to_owned(),
+                // }),
+                Err(RaidenError::AttributeConvertError {
                     attr_name: "unstored".to_owned(),
                 }),
+            );
+        }
+        rt.block_on(example());
+    }
+
+    #[derive(Raiden)]
+    #[raiden(table_name = "user")]
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UserWithEmptyHashSet {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        empty_set: std::collections::HashSet<usize>,
+    }
+
+    #[test]
+    fn test_get_empty_hashset() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UserWithEmptyHashSet::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let res = client.get("user_primary_key").consistent().run().await;
+            assert_eq!(
+                res.unwrap(),
+                get::GetOutput {
+                    item: UserWithEmptyHashSet {
+                        id: "user_primary_key".to_owned(),
+                        name: "bokuweb".to_owned(),
+                        empty_set: std::collections::HashSet::new(),
+                    },
+                    consumed_capacity: None,
+                }
+            );
+        }
+        rt.block_on(example());
+    }
+
+    #[derive(Raiden)]
+    #[raiden(table_name = "user")]
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UserWithEmptyVec {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        empty_vec: Vec<usize>,
+    }
+
+    #[test]
+    fn test_get_empty_vec() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UserWithEmptyVec::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let res = client.get("user_primary_key").consistent().run().await;
+            assert_eq!(
+                res.unwrap(),
+                get::GetOutput {
+                    item: UserWithEmptyVec {
+                        id: "user_primary_key".to_owned(),
+                        name: "bokuweb".to_owned(),
+                        empty_vec: vec![],
+                    },
+                    consumed_capacity: None,
+                }
             );
         }
         rt.block_on(example());

--- a/raiden/tests/all/put.rs
+++ b/raiden/tests/all/put.rs
@@ -126,9 +126,7 @@ mod tests {
                 id: "id0".to_owned(),
                 name: "bokuweb".to_owned(),
             };
-            let cond = User::condition()
-                .value("bokuweb")
-                .eq_attr(User::name());
+            let cond = User::condition().value("bokuweb").eq_attr(User::name());
             let res = client.put(user).condition(cond).run().await;
             assert_eq!(res.is_ok(), true);
         }
@@ -147,9 +145,7 @@ mod tests {
                 id: "id0".to_owned(),
                 name: "bokuweb".to_owned(),
             };
-            let cond = User::condition()
-                .value("bokuweb_")
-                .eq_attr(User::name());
+            let cond = User::condition().value("bokuweb_").eq_attr(User::name());
             let res = client.put(user).condition(cond).run().await;
             assert_eq!(
                 Err(::raiden::RaidenError::ConditionalCheckFailed(
@@ -298,7 +294,7 @@ mod tests {
     }
 
     impl raiden::FromAttribute for Custom {
-        fn from_attr(value: raiden::AttributeValue) -> Result<Self, ()> {
+        fn from_attr(value: Option<raiden::AttributeValue>) -> Result<Self, ()> {
             Ok(Custom {})
         }
     }


### PR DESCRIPTION
## What does this change?

I changed `FromAttribute` interface to support empty `HashSet` and `Vec`. 

- before
``` Rust
pub trait FromAttribute: Sized {
    fn from_attr(value: AttributeValue) -> Result<Self, ()>;
}
```

- after
``` Rust
pub trait FromAttribute: Sized {
    fn from_attr(value: Option<AttributeValue>) -> Result<Self, ()>;
}
```

It is able to return empty `HashSet` and `Vec` like following. when attribute not found. And user can define a behavior when attribute not found.However, I believe this change will affect #27. @kuy 

``` Rust
impl<A: FromAttribute + std::hash::Hash + std::cmp::Eq> FromAttribute
    for std::collections::HashSet<A>
{
    fn from_attr(value: Option<AttributeValue>) -> Result<Self, ()> {
        if value.is_none() {
            return Ok(std::collections::HashSet::new()); // An User can defined a behavior when item not found
        }
        value
            .unwrap()
            .l
            .ok_or((/* TODO: Add convert error handling */))?
            .into_iter()
            .map(|item| A::from_attr(Some(item)))
            .collect()
    }
}
```

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

NA
