### PR TITLE
fix: Ignore empty attributeValue to pass empty set and vec put

### DIFF
--- a/raiden-derive/src/ops/put.rs
+++ b/raiden-derive/src/ops/put.rs
@@ -69,10 +69,13 @@ pub(crate) fn expand_put_item(
                 }
             } else {
                 quote! {
-                    input_item.insert(
-                        #attr_key.to_string(),
-                        item.#ident.clone().into_attr(),
-                    );
+                    let value = item.#ident.clone().into_attr();
+                    if !::raiden::is_attr_value_empty(&value) {
+                        input_item.insert(
+                            #attr_key.to_string(),
+                            value,
+                        );
+                    }
                 }
             }
         });

--- a/raiden-derive/src/ops/transact_write.rs
+++ b/raiden-derive/src/ops/transact_write.rs
@@ -46,10 +46,13 @@ pub(crate) fn expand_transact_write(
                 }
             } else {
                 quote! {
-                    input_item.insert(
-                        #attr_key.to_string(),
-                        item.#ident.clone().into_attr(),
-                    );
+                    let value = item.#ident.into_attr();
+                    if !::raiden::is_attr_value_empty(&value) {
+                        input_item.insert(
+                            #attr_key.to_string(),
+                            value,
+                        );
+                    }
                 }
             }
         });

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -268,6 +268,9 @@ impl FromStringSetItem for String {
 
 impl<A: IntoAttribute> IntoAttribute for Vec<A> {
     fn into_attr(mut self: Self) -> AttributeValue {
+        if self.is_empty() {
+            return AttributeValue::default();
+        }
         AttributeValue {
             l: Some(self.drain(..).map(|s| s.into_attr()).collect()),
             ..AttributeValue::default()
@@ -292,6 +295,9 @@ impl<A: FromAttribute> FromAttribute for Vec<A> {
 
 impl IntoAttribute for std::collections::HashSet<usize> {
     fn into_attr(self: Self) -> AttributeValue {
+        if self.is_empty() {
+            return AttributeValue::default();
+        }
         AttributeValue {
             ns: Some(self.into_iter().map(|s| s.to_string()).collect()),
             ..AttributeValue::default()
@@ -315,6 +321,9 @@ impl FromAttribute for std::collections::HashSet<usize> {
 
 impl<A: std::hash::Hash + IntoStringSetItem> IntoAttribute for std::collections::HashSet<A> {
     fn into_attr(self: Self) -> AttributeValue {
+        if self.is_empty() {
+            return AttributeValue::default();
+        }
         AttributeValue {
             ss: Some(self.into_iter().map(|s| s.into_ss_item()).collect()),
             ..AttributeValue::default()
@@ -344,4 +353,8 @@ pub fn merge_map<T>(
     map2: std::collections::HashMap<String, T>,
 ) -> std::collections::HashMap<String, T> {
     map1.into_iter().chain(map2).collect()
+}
+
+pub fn is_attr_value_empty(a: &AttributeValue) -> bool {
+    a == &AttributeValue::default()
 }

--- a/raiden/tests/all/put.rs
+++ b/raiden/tests/all/put.rs
@@ -328,4 +328,35 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden)]
+    #[raiden(table_name = "user")]
+    #[derive(Debug, Clone)]
+    pub struct UserEmptySetTest {
+        #[raiden(partition_key)]
+        #[raiden(uuid)]
+        id: String,
+        set: std::collections::HashSet<String>,
+    }
+
+    #[test]
+    fn test_put_user_with_empty_set() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UserEmptySetTest::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let set: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            let item = UserEmptySetTest::put_item_builder()
+                .set(set)
+                .build()
+                .unwrap();
+            let res = client.put(item).run().await;
+            dbg!(&res);
+            assert_eq!(res.is_ok(), true);
+        }
+        rt.block_on(example());
+    }
 }


### PR DESCRIPTION
## What does this change?

Ignore empty attributeValue to pass empty set and vec when put

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
