### PR TITLE
Improve type check of sort key

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ make test
 
 NOTE: Don't recommend to use `cargo test` because our test suite doesn't support running tests in parallel. Use `cargo test -- --test-threads=1` instead of it.
 
+### Utility
+
+[dynamodb-admin](https://github.com/aaronshaf/dynamodb-admin) is useful to check data in DynamoDB Local.
+
+```
+npx dynamodb-admin
+```
+
+Then open `http://localhost:8001` in browser.
+
 ## Known limitations
 
 Here is a list of unsupported features/behaviors in the actual implementation.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ make dynamo
 make test
 ```
 
+NOTE: Don't recommend to use `cargo test` because our test suite doesn't support running tests in parallel. Use `cargo test -- --test-threads=1` instead of it.
+
 ## Known limitations
 
 Here is a list of unsupported features/behaviors in the actual implementation.

--- a/raiden-derive/src/ops/get.rs
+++ b/raiden-derive/src/ops/get.rs
@@ -15,19 +15,19 @@ pub(crate) fn expand_get_item(
     let client_trait = if let Some(sort_key) = sort_key {
         quote! {
             pub trait #trait_name {
-                fn get<PK, SK>(&self, key: (PK, SK)) -> #builder_name
+                fn get<PK, SK>(&self, pk: PK, sk: SK) -> #builder_name
                     where PK: ::raiden::IntoAttribute + std::marker::Send,
                           SK: ::raiden::IntoAttribute + std::marker::Send;
             }
 
             impl #trait_name for #client_name {
-                fn get<PK, SK>(&self, key: (PK, SK)) -> #builder_name
+                fn get<PK, SK>(&self, pk: PK, sk: SK) -> #builder_name
                     where PK: ::raiden::IntoAttribute + std::marker::Send,
                           SK: ::raiden::IntoAttribute + std::marker::Send
                 {
                     let mut input = ::raiden::GetItemInput::default();
-                    let pk_attr: AttributeValue = key.0.into_attr();
-                    let sk_attr: AttributeValue = key.1.into_attr();
+                    let pk_attr: AttributeValue = pk.into_attr();
+                    let sk_attr: AttributeValue = sk.into_attr();
                     let mut key_set: std::collections::HashMap<String, AttributeValue> = std::collections::HashMap::new();
                     key_set.insert(stringify!(#partition_key).to_owned(), pk_attr);
                     key_set.insert(stringify!(#sort_key).to_owned(), sk_attr);

--- a/raiden/examples/delete.rs
+++ b/raiden/examples/delete.rs
@@ -19,7 +19,7 @@ fn main() {
             name: "ap-northeast-1".into(),
         });
 
-        let res = client.delete("id1").sort_key(2003).run().await;
+        let res = client.delete("id1", 2003).run().await;
         dbg!(&res);
     }
     rt.block_on(example());

--- a/raiden/tests/all/delete.rs
+++ b/raiden/tests/all/delete.rs
@@ -61,4 +61,28 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden, Debug, Clone)]
+    pub struct DeleteTest1 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        year: usize,
+    }
+
+    #[test]
+    fn test_delete_item_with_sort_key() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = DeleteTest1::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+
+            let res = client.delete("id0").sort_key(1999).run().await;
+            assert_eq!(res.is_ok(), true);
+        }
+        rt.block_on(example());
+    }
 }

--- a/raiden/tests/all/delete.rs
+++ b/raiden/tests/all/delete.rs
@@ -80,7 +80,7 @@ mod tests {
                 name: "ap-northeast-1".into(),
             });
 
-            let res = client.delete("id0").sort_key(1999).run().await;
+            let res = client.delete("id0", 1999).run().await;
             assert_eq!(res.is_ok(), true);
         }
         rt.block_on(example());

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -281,4 +281,41 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden, Debug, PartialEq)]
+    #[raiden(table_name = "QueryTestData0")]
+    pub struct UserWithSortKey {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        year: usize,
+        num: usize,
+    }
+
+    #[test]
+    fn test_user_get_item_with_sort_key() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UserWithSortKey::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+
+            let res = client.get("id1").sort_key(2003).run().await;
+            assert_eq!(
+                res.unwrap(),
+                get::GetOutput {
+                    item: UserWithSortKey {
+                        id: "id1".to_owned(),
+                        name: "bob".to_owned(),
+                        year: 2003,
+                        num: 300,
+                    },
+                    consumed_capacity: None,
+                }
+            );
+        }
+        rt.block_on(example());
+    }
 }

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -95,28 +95,6 @@ mod tests {
         rt.block_on(example());
     }
 
-    /*
-    #[test]
-    fn test_user_get_item_with_unmatched_key_type() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
-        async fn example() {
-            let client = UserClient::new(Region::Custom {
-                endpoint: "http://localhost:8000".into(),
-                name: "ap-northeast-1".into(),
-            });
-            let res = client.get(2020).consistent().run().await;
-            assert_eq!(
-                res,
-                Err(RaidenError::ResourceNotFound(
-                    "resource not found".to_owned()
-                )),
-            );
-        }
-        rt.block_on(example());
-    }
-
-    */
-
     #[derive(Raiden)]
     #[raiden(table_name = "user")]
     #[derive(Debug, Clone, PartialEq)]
@@ -324,7 +302,7 @@ mod tests {
                 name: "ap-northeast-1".into(),
             });
 
-            let res = client.get(("id1", 2003)).run().await;
+            let res = client.get("id1", 2003).run().await;
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -95,6 +95,28 @@ mod tests {
         rt.block_on(example());
     }
 
+    /*
+    #[test]
+    fn test_user_get_item_with_unmatched_key_type() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UserClient::new(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let res = client.get(2020).consistent().run().await;
+            assert_eq!(
+                res,
+                Err(RaidenError::ResourceNotFound(
+                    "resource not found".to_owned()
+                )),
+            );
+        }
+        rt.block_on(example());
+    }
+
+    */
+
     #[derive(Raiden)]
     #[raiden(table_name = "user")]
     #[derive(Debug, Clone, PartialEq)]
@@ -302,7 +324,7 @@ mod tests {
                 name: "ap-northeast-1".into(),
             });
 
-            let res = client.get("id1").sort_key(2003).run().await;
+            let res = client.get(("id1", 2003)).run().await;
             assert_eq!(
                 res.unwrap(),
                 get::GetOutput {

--- a/raiden/tests/all/update.rs
+++ b/raiden/tests/all/update.rs
@@ -109,9 +109,46 @@ mod tests {
                 .run()
                 .await
                 .unwrap();
+            assert_eq!(res.item, None,);
+        }
+        rt.block_on(example());
+    }
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct UpdateTestData1 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        age: usize,
+    }
+
+    #[test]
+    fn test_update_with_sort_key() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UpdateTestData1::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let set_expression = UpdateTestData1::update_expression()
+                .set(UpdateTestData1::name())
+                .value("bob");
+            let res = client
+                .update("id0")
+                .sort_key(36)
+                .set(set_expression)
+                .return_all_new()
+                .run()
+                .await
+                .unwrap();
             assert_eq!(
                 res.item,
-                None,
+                Some(UpdateTestData1 {
+                    id: "id0".to_owned(),
+                    name: "bob".to_owned(),
+                    age: 36
+                })
             );
         }
         rt.block_on(example());

--- a/raiden/tests/all/update.rs
+++ b/raiden/tests/all/update.rs
@@ -135,8 +135,7 @@ mod tests {
                 .set(UpdateTestData1::name())
                 .value("bob");
             let res = client
-                .update("id0")
-                .sort_key(36)
+                .update("id0", 36)
                 .set(set_expression)
                 .return_all_new()
                 .run()

--- a/setup/index.js
+++ b/setup/index.js
@@ -232,7 +232,7 @@ const put = (params) =>
     TableName: 'BatchTest0',
     KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
     AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
-    ProvisionedThroughput: { ReadCapacityUnits: 50, WriteCapacityUnits: 50 },
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
   });
 
   for (let i = 0; i < 101; i++) {
@@ -314,6 +314,28 @@ const put = (params) =>
       id: { S: 'id1' },
       name: { S: 'bokuweb' },
       removable: { BOOL: true },
+    },
+  });
+
+  await createTable({
+    TableName: 'DeleteTest1',
+    KeySchema: [
+      { AttributeName: 'id', KeyType: 'HASH' },
+      { AttributeName: 'year', KeyType: 'RANGE' },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: 'id', AttributeType: 'S' },
+      { AttributeName: 'year', AttributeType: 'N' },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  });
+
+  await put({
+    TableName: 'DeleteTest1',
+    Item: {
+      id: { S: 'id0' },
+      name: { S: 'alice' },
+      year: { N: '1999' },
     },
   });
 })();

--- a/setup/index.js
+++ b/setup/index.js
@@ -141,6 +141,23 @@ const put = (params) =>
   });
 
   await createTable({
+    TableName: 'UpdateTestData1',
+    KeySchema: [
+      { AttributeName: 'id', KeyType: 'HASH' },
+      { AttributeName: 'age', KeyType: 'RANGE' },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: 'id', AttributeType: 'S' },
+      { AttributeName: 'age', AttributeType: 'N' },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  });
+  await put({
+    TableName: 'UpdateTestData1',
+    Item: { id: { S: 'id0' }, name: { S: 'john' }, age: { N: '36' } },
+  });
+
+  await createTable({
     TableName: 'PutItemConditionData0',
     KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
     AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],


### PR DESCRIPTION
## What does this change?

This changes give a heads up about a missing sort key in compile time, not runtime.

```rust
let res = client.get("id1").run().await; // error 🔥 

let res = client.get("id1", 2003).run().await; // awesome 🚀 
```

### Affected operations

- [x] `get`
- [x] `delete`
- [x] `update`

## Breaking changes ⚠️ 

### `get` op

#### Before 

```rust
let res = client.get("id1").sort_key(2003).run().await;
```

#### After

```rust
let res = client.get("id1", 2003).run().await;
```

### `delete` op

#### Before 

```rust
let res = client.delete("id0").sort_key(2003).run().await;
```

#### After

```rust
let res = client.delete("id0", 2003).run().await;
```

### `update` op

#### Before 

```rust
let res = client
    .update("id0")
    .sort_key(36)
    .set(set_expression)
    ....
```

#### After

```rust
let res = client
    .update("id0", 36)
    .set(set_expression)
    ....
```

*NOTE: No change in tables only partition key*

## References

https://github.com/raiden-rs/raiden/issues/26

## Screenshots

![Screen Shot 2020-07-09 at 22 42 59](https://user-images.githubusercontent.com/151614/87048555-ceb1c200-c236-11ea-8cb4-d5b552be5bad.png)

## What can I check for bug fixes?

See [test code](https://github.com/raiden-rs/raiden/pull/46/files#diff-f30a3f3d7071dd25ce4429bdf4b56ab8)

## Not focus

More strict type checking: https://github.com/raiden-rs/raiden/issues/47